### PR TITLE
Added support for AMD loaders

### DIFF
--- a/src/qwest.js
+++ b/src/qwest.js
@@ -8,10 +8,11 @@
 */
 
 (function(def){
-    if(typeof module!='undefined'){
+    if(typeof define=='function'&&define.amd){
+      define(def);
+    } else if(typeof module!='undefined'){
         module.exports=def;
-    }
-    else{
+    } else{
         this.qwest=def;
     }
 }(function(){


### PR DESCRIPTION
A simple fix enables AMD loaders such as [RequireJS](http://requirejs.org/) to use this package. I haven't tested the CommonJS version since I don't use it, but I don't see why it wouldn't work as expected.
