### PR TITLE
Use jQuery's param implementation to build data params 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,7 @@ module.exports = function(grunt) {
 				predef		: [
 					'Document',
 					'define',
+					'require',
 					'module',
 					'ActiveXObject',
 					'console',

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "grunt-shell": "^1.1.1",
     "grunt-string-replace": "^1.0.0",
     "jit-grunt": "^0.9.0"
+  },
+  "dependencies": {
+    "jquery-param": "^0.1.1"
   }
 }

--- a/src/qwest.js
+++ b/src/qwest.js
@@ -29,7 +29,7 @@
 			},
 		// Guess XHR version
 		xhr2=(getXHR().responseType===''),
-		jqueryParam = require('jquery-param')
+		jqueryParam = require('jquery-param'),
 
 	// Core function
 	qwest=function(method,url,data,options,before){
@@ -251,27 +251,6 @@
 					func.call(xhr);
 				}
 			}
-		},
-
-		// Recursively build the query string
-		buildData=function(data,key){
-			var res=[],
-				enc=encodeURIComponent,
-				p;
-			if(typeof data==='object' && data!=null) {
-				for(p in data) {
-					if(data.hasOwnProperty(p)) {
-						var built=buildData(data[p],key?key+'['+p+']':p);
-						if(built!==''){
-							res=res.concat(built);
-						}
-					}
-				}
-			}
-			else if(data!=null && key!=null){
-				res.push(enc(key)+'='+enc(data));
-			}
-			return res.join('&');
 		};
 
 		// New request

--- a/src/qwest.js
+++ b/src/qwest.js
@@ -29,6 +29,7 @@
 			},
 		// Guess XHR version
 		xhr2=(getXHR().responseType===''),
+		jqueryParam = require('jquery-param')
 
 	// Core function
 	qwest=function(method,url,data,options,before){
@@ -316,7 +317,7 @@
 				data=JSON.stringify(data);
 				break;
 			case 'post':
-				data=buildData(data);
+				data=jqueryParam(data);
 		}
 
 		// Prepare headers


### PR DESCRIPTION
Hi, currently qwest have some issues when serialize array data, I found it's better to use jQuery's param function to build data params, and someone have just extracted an individual module [jquery-param](https://github.com/knowledgecode/jquery-param), which is nice.

I don't know what's the best way to require additional modules, we need package for minified version, this PR works fine for webpack (and also browserify I guess).