### PR TITLE
Adding window reference on XMLHttpRequest initialization

### DIFF
--- a/src/qwest.js
+++ b/src/qwest.js
@@ -23,7 +23,7 @@
 		// Get XMLHttpRequest object
 		getXHR = function(){
 			return win.XMLHttpRequest?
-					new XMLHttpRequest():
+					new win.XMLHttpRequest():
 					new ActiveXObject('Microsoft.XMLHTTP');
 		},
 		// Guess XHR version


### PR DESCRIPTION
Not specifying the window object leads to problems on projects/scenarios where the global context is not what you think it is. To me this makes mocha fail on:
```javascript
ReferenceError: XMLHttpRequest is not defined
    at getXHR (/Users/developer/workspace/watch/node_modules/qwest/build/qwest.min.js:1:1939)
```