### PR TITLE
use Cache-Control header to avoid ajax cache but not timestamp appended to url

### DIFF
--- a/src/qwest.js
+++ b/src/qwest.js
@@ -339,7 +339,7 @@
 			if(vars) {
 				vars += '&';
 			}
-			vars += '__t='+(+new Date());
+			headers['Cache-Control'] = 'no-cache';
 		}
 		if(vars) {
 			url += (/\?/.test(url)?'&':'?')+vars;


### PR DESCRIPTION
use the timestamp to avoid ajax cache is not a  elegance way
1.it will damaged the url semantic if I use restful
2.it may case 404 error when the server can not filter the _t query param
3.timestamp way will not work in old IE sometimes(<=8)
4.it not elegance