### PR TITLE
Skip Cache-Control header if other cache control value is passed

### DIFF
--- a/src/qwest.js
+++ b/src/qwest.js
@@ -111,7 +111,7 @@
 				// Set headers
 				if(!xdr) {
 					for(var i in headers) {
-						if (headers[t] && headers[t]) {
+						if (headers[t]) {
 							xhr.setRequestHeader(i, headers[i]);
 						}
 					}

--- a/src/qwest.js
+++ b/src/qwest.js
@@ -111,7 +111,9 @@
 				// Set headers
 				if(!xdr) {
 					for(var i in headers) {
-						xhr.setRequestHeader(i, headers[i]);
+						if (headers[t] && headers[t]) {
+							xhr.setRequestHeader(i, headers[i]);
+						}
 					}
 				}
 				// Verify if the response type is supported by the current browser
@@ -330,7 +332,7 @@
 		if(!crossOrigin && !headers['X-Requested-With']) { // (that header breaks in legacy browsers with CORS)
 			headers['X-Requested-With'] = 'XMLHttpRequest';
 		}
-		if(!options.cache) {
+		if(!options.cache && !('Cache-Control' in headers)) {
 			headers['Cache-Control'] = 'no-cache';
 		}
 

--- a/tests/qwest.js
+++ b/tests/qwest.js
@@ -281,7 +281,7 @@
 				// Set headers
 				if(!xdr) {
 					for(var i in headers) {
-						if (headers[t] && headers[t]) {
+						if (headers[t]) {
 							xhr.setRequestHeader(i, headers[i]);
 						}
 					}

--- a/tests/qwest.js
+++ b/tests/qwest.js
@@ -281,7 +281,9 @@
 				// Set headers
 				if(!xdr) {
 					for(var i in headers) {
-						xhr.setRequestHeader(i, headers[i]);
+						if (headers[t] && headers[t]) {
+							xhr.setRequestHeader(i, headers[i]);
+						}
 					}
 				}
 				// Verify if the response type is supported by the current browser
@@ -500,7 +502,7 @@
 		if(!crossOrigin && !headers['X-Requested-With']) { // (that header breaks in legacy browsers with CORS)
 			headers['X-Requested-With'] = 'XMLHttpRequest';
 		}
-		if(!options.cache) {
+		if(!options.cache && !('Cache-Control' in headers)) {
 			headers['Cache-Control'] = 'no-cache';
 		}
 


### PR DESCRIPTION
Pull request for #74 -- skip cache-control header if previously defined.