### PR TITLE
Change main entry in package.json to source file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/pyrsmk/qwest.git"
   },
-  "main": "qwest.js",
+  "main": "src/qwest.js",
   "keywords": [
     "ajax",
     "request",


### PR DESCRIPTION
Currently, the main entry in package.json point to a pre-built file, and when require qwest with webpack, there will be a warning:

> This seems to be a pre-built javascript file

I think it's a good practice to keep webpack to handle the build process.