### PR TITLE
little performance improve

### DIFF
--- a/src/qwest.js
+++ b/src/qwest.js
@@ -14,10 +14,10 @@ module.exports = function() {
 		requests = 0,
 		request_stack = [],
 		// Get XMLHttpRequest object
-		getXHR = function(){
-			return global.XMLHttpRequest?
-					new global.XMLHttpRequest():
-					new ActiveXObject('Microsoft.XMLHTTP');
+		getXHR = global.XMLHttpRequest? function(){
+			return new global.XMLHttpRequest();
+		}: function(){
+			return new ActiveXObject('Microsoft.XMLHTTP');
 		},
 		// Guess XHR version
 		xhr2 = (getXHR().responseType===''),


### PR DESCRIPTION
I think we don't need to detect `global.XMLHttpRequest` in each `getXHR()` call.